### PR TITLE
Make cursor invisible instead of scaling

### DIFF
--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -329,12 +329,12 @@ class UIRoot extends Component {
       const cursor = document.querySelector("#right-cursor");
       if (this.state.isRecordingMode) {
         // If isRecordingMode is true then toggle it off.
-        cursor.setAttribute("scale", { x: 1, y: 1, z: 1 });
+        cursor.object3D.children[1].material.visible = true;
         this.setState({ hide: false, hideUITip: false, isRecordingMode: false });
         document.querySelector(".rs-fps-counter").style.visibility = "visible";
         document.querySelector(".rs-base").style.visibility = "visible";
       } else {
-        cursor.setAttribute("scale", { x: 0, y: 0, z: 0 });
+        cursor.object3D.children[1].material.visible = false;
         this.setState({ hide: true, hideUITip: true, isRecordingMode: true });
         document.querySelector(".rs-fps-counter").style.visibility = "hidden";
         document.querySelector(".rs-base").style.visibility = "hidden";


### PR DESCRIPTION
As I mentioned at the collaborative hacking session on Saturday, here is some code to make the cursor invisible without changing the scale.
While there isn't much difference in the end result, I do want to note that with the scaling method, the cursor will show up again when it hovers over an object, but making it invisible will keep it hidden (the blue flashing glow is present with both methods).